### PR TITLE
Correct grammar of documentation command

### DIFF
--- a/AVAILABLE_COMMANDS.md
+++ b/AVAILABLE_COMMANDS.md
@@ -40,7 +40,7 @@ _examples_
 
 [Source](https://github.com/campDevs/DiscordBot/blob/master/src/commands/code/FormatCommand.js)  
 ### catuscode  
-Description: Loads an cat-related picture demonstrating various HTTP status codes  
+Description: Loads a cat-related picture demonstrating various HTTP status codes  
 
 _examples_
 +  catuscode 500

--- a/src/commands/fetch/CatusCodeCommand.js
+++ b/src/commands/fetch/CatusCodeCommand.js
@@ -9,7 +9,7 @@ module.exports = class CatusCodeCommand extends Command {
       name: "catuscode",
       group: "fetch",
       memberName: "catuscode",
-      description: "Loads an cat-related picture demonstrating various HTTP status codes",
+      description: "Loads a cat-related picture demonstrating various HTTP status codes",
       examples: ['catuscode 500', 'catuscode 301'],
       throttling: {
         usages: 1,


### PR DESCRIPTION
📗 Pulling from this branch is safe.

The "CatusCode" command's documentation used the indefinite article "an". This is only used when the next sound is that of a vowel. However, in this case, the next sound was /k/, which is a consonant. Therefore, the correct indefinite article should've been "a".

I have therefore changed the indefinite article from "an" to "a".