### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- Thank you for stopping by to make a pull request -->
 
-<!-- Report security bugs to <septimus98@gmail.com>, we will review them as soon as possible -->
+<!-- Report security bugs to <septimus98@gmail.com>, we will review them as soon as possible (you might want to send your patch to that email so we can review it withoout disclosing the issue) -->
 
 # Resolves
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!-- Thank you for stopping by to make a pull request -->
+
+<!-- Report security bugs to <septimus98@gmail.com>, we will review them as soon as possible -->
+
+# Resolves
+
+<!-- Does your pull request resolve an issue? Insert that issue number where it says "XXXX" -->
+
+Resolves XXXX
+
+# Changes
+
+<!-- Describe which files you changed and why -->
+
+# Testing
+
+<!-- Describe which tests you performed (either manual or automatic)
+
+# Screenshots
+
+<!-- If any. Remove if none. -->
+
+# Other notes
+
+<!-- If any. Remove if none. -->


### PR DESCRIPTION
Resolves #57 
The pull request template is designed to make it easier to review new
pull requests. All notes to the requester are made using comments (`<!--
-->`), and this is different to freeCodeCamp's method. However, this
removes the need for the requester to delete those notes. We could add an issue template, but I find these tend to be a little unhelpful as issues can be a broad variety of things.

Four sections are added. These are described under their respective
headings.

# Resolves
GitHub has the ability to "link" pull requests to issues. If you place
"Closes #XXXX" or "Resolves #XXXX", then when the pull request is
merged, the linked issue is also closed. The phrase "Resolves XXXX" is
included in the template, and a note states to replace the Xs. In
addition, the reviewer can quickly visit the relevant issue to determine
what the changes were meant to look like. Finally, waffle.io relies on
these I believe.

# Changes
This allows the requester to provide a summary to the reviewer for why
certain changes were made, and what they do. They should make it a lot
easier for the reviewer to quickly understand code that they would
otherwise take a while to decipher.

# Testing
This includes both manual and automatic testing. I don't believe we
currently use automatic testing (except Travis), but future-proofing
never hurts. This reminds the requester that they should make sure their
code works -- this will save time for the reviewer, as they won't be
needlessly testing useless code.

# Screenshots
This is marked as an optional category. Any screenshots that could
assist onlookers in understanding what the pull request does.

# Other notes
This is marked as an optional category. Anything else the reviewer feels
they need to mention.