### PR TITLE
Add "issue" command

### DIFF
--- a/AVAILABLE_COMMANDS.md
+++ b/AVAILABLE_COMMANDS.md
@@ -5,6 +5,7 @@ The following list of commands are in the order they appear in the source.
 ### Current Commands
 +  **assistants**
    +  [lmgtfy](#lmgtfy)
+   +  [issue](#issue)
 +  **code**
    +  [format](#format)
 +  **fetch**
@@ -30,7 +31,18 @@ _examples_
 +   lmgtfy js vs python  
 +   lmgtfy How do I google something?  
 
+
 [Source](https://github.com/campDevs/DiscordBot/blob/master/src/commands/assistants/LmgtfyCommand.js)  
+### issue
+Description: Link to report bugs and request features about the bot.
+
+_examples_
++  issue
++  issue Add better memes
++  issue Add better memes // Let's add better meme support. For example, none of the memes are memes.
+
+
+[Source](https://github.com/campDevs/DiscordBot/blob/master/src/commands/assistants/Issue.js) 
 ### format   
 Description: Formats code in the provided language  
 

--- a/src/commands/assistants/Issue.js
+++ b/src/commands/assistants/Issue.js
@@ -1,0 +1,37 @@
+const {Command} = require('discord.js-commando')
+
+module.exports = class LmgtfyCommand extends Command {
+  constructor(client) {
+    super(client, {
+      name: "issue",
+	  aliases: ["bug", "request"],
+      group: "assistants",
+      memberName: "issue",
+      description: "Link to report bugs and request features about the bot.",
+      examples: [
+        "issue",
+        "issue Add better memes",
+		"issue Add better memes // Let's add better meme support. For example, none of the memes are memes."],
+      args: [
+        {
+          key: "content",
+          prompt: "",
+          type: "string",
+		  default: "",
+        }
+      ]
+    })
+  }
+
+  run(msg, {content}) {
+    const [title, body] = content.split("//").map(s => s.trim()).concat("", "")
+	return msg.channel.send({
+		embed: {
+			title: "File an issue (for bugs and feature requests about this bot) on GitHub",
+			description: title ? "The content you specified will be prefilled" : "",
+			url: "https://github.com/campDevs/DiscordBot/issues/new/" + (title && `?title=${encodeURIComponent(title)}`) + (body && `&body=${encodeURIComponent(body)}`),
+			footer: {"text": "Making GitHub issues requires a free account."}
+		}
+	})
+  }
+}

--- a/src/commands/assistants/Issue.js
+++ b/src/commands/assistants/Issue.js
@@ -1,6 +1,6 @@
 const {Command} = require('discord.js-commando')
 
-module.exports = class LmgtfyCommand extends Command {
+module.exports = class IssueCommand extends Command {
   constructor(client) {
     super(client, {
       name: "issue",

--- a/src/commands/assistants/Issue.js
+++ b/src/commands/assistants/Issue.js
@@ -10,8 +10,8 @@ module.exports = class IssueCommand extends Command {
       description: "Link to report bugs and request features about the bot.",
       examples: [
         "issue",
-        "issue Add better memes",
-		"issue Add better memes // Let's add better meme support. For example, none of the memes are memes."],
+        "issue Title of my issue",
+		"issue Title of my issue // Description of my issue"],
       args: [
         {
           key: "content",
@@ -27,7 +27,7 @@ module.exports = class IssueCommand extends Command {
     const [title, body] = content.split("//").map(s => s.trim()).concat("", "")
 	return msg.channel.send({
 		embed: {
-			title: "File an issue (for bugs and feature requests about this bot) on GitHub",
+			title: "CLICK HERE to File an issue (for bugs and feature requests about this bot) on GitHub",
 			description: title ? "The content you specified will be prefilled" : "",
 			url: "https://github.com/campDevs/DiscordBot/issues/new/" + (title && `?title=${encodeURIComponent(title)}`) + (body && `&body=${encodeURIComponent(body)}`),
 			footer: {"text": "Making GitHub issues requires a free account."}


### PR DESCRIPTION
Resolves #25 (Add command that directs users to file issues here)

Original (failed) PR: #72 

Syntax:

```
-issue

-issue Title Goes Here

-issue Title Goes Here // Content Goes Here
```

Alias:
- `bug`
- `request`

Links to the new issue page (filled with values passed to the bot where relevant).