### PR TITLE
Remove deprecated method

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -62,8 +62,8 @@ client.on('message', async msg => {
 })
 
 function sendMsgToAuditChannel(guild, msg) {
-  if (guild.channels.exists("name", config.auditChannel) && config.adminTransparency) {
-    let auditChannel = guild.channels.find("name", config.auditChannel)
+  let auditChannel = guild.channels.find("name", config.auditChannel)
+  if (auditChannel && config.adminTransparency) {
     auditChannel.send(msg)
   }
 }


### PR DESCRIPTION
Remove the deprecated method Collection#exists as it is obsolete.
This also makes the code more efficient, as it doesn't need to calculate
the value twice (once explicitly, once under the hood). This is an
urgent fix as the deprecated method was removed and broke the bot.

Resolves #87
Resolves #88