### PR TITLE
Implement a Command-line Interface (CLI) 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,12 +16,11 @@ TOKEN=<Bot Token>
 ```
 * Replace `<Bot Token>` with your bot token acquired in the prerequisite step "Get your bot token."
 
-* Copy or rename `example_config.json` to `config.json`. Add your user id to the "owners" array.
+* Enter the `src` directory and start the CLI, and then fill in any details. Hit enter for any question to use the default value. To set yourself as the owner of the bot, you'll need to know your user ID -- see the prerequisite step "Get your uuser id"
 
-```json
-{
-    "owners": ["YOUR USER ID"]
-}
+```bash
+cd src
+node setup
 ```
 
 * `npm start`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ Thanks to [all of our Contributors](https://github.com/campDevs/DiscordBot/contr
 
 ## Deployment
 ### Glitch.com
-Click [![Remix on Glitch](https://cdn.glitch.com/2703baf2-b643-4da7-ab91-7ee2a2d00b5b%2Fremix-button.svg)](https://glitch.com/edit/#!/import/github/https://github.com/campDevs/DiscordBot/) and add your bot's token to the `.env` file as `TOKEN=<Bot Token>`. Additionally you can add your discord id as an owner `OWNER_ID=<Discord User ID>`.
+Click [![Remix on Glitch](https://cdn.glitch.com/2703baf2-b643-4da7-ab91-7ee2a2d00b5b%2Fremix-button.svg)](https://glitch.com/edit/#!/import/github/https://github.com/campDevs/DiscordBot/) and add your bot's token to the `.env` file as `TOKEN=<Bot Token>`. Then, you can set your bot up with our CLI.
+
+```bash
+cd src
+node setup
+```
+And follow the instructions. Hit enter for any question to use the default option.
 
 Note that glitch.com will sleep after inactivity and your bot will stop responding. You can reawaken your bot by visiting it on glitch.com.
 

--- a/src/defaults.json
+++ b/src/defaults.json
@@ -1,6 +1,6 @@
 {
   "prefix": "+",
   "owners": [""],
-  "adminTransparency": "true",
+  "adminTransparency": true,
   "auditChannel": "moderation"
 }

--- a/src/setup.js
+++ b/src/setup.js
@@ -99,6 +99,8 @@ handleField(CONFIG_FIELDS.shift())
 
 function handleField(configElement) {
   if(typeof configElement === 'undefined') {
+    // There are no more questions to answer
+    console.log(jsonToString(config))
     return
   }
  
@@ -141,5 +143,28 @@ function recursiveQuestion(arg, conditionFunction, cb) {
       recursiveQuestion(...arguments)
     }
   })
+}
+
+/**
+ * A work-in-progress function to create JSON strings that contain whitespace. The
+ * function works recursively. Do not pass it circular objects, it will
+ * not detect it and the recursive stack will overflow.
+ *
+ * @todo Handle indentation when nesting objects
+ *
+ * @param {*} obj - The object to convert to JSON
+ * @return {string} The stringified JSON
+ */
+function jsonToString(obj) {
+  if(Array.isArray(obj)) {
+    return obj.map(i => jsonToString(i)).join(', '.cyan)
+  }
+  if(typeof obj === 'string') {
+    return JSON.stringify(obj).red
+  }
+  if(typeof obj === 'boolean') {
+    return JSON.stringify(obj).green
+  }
+  return '{\n'.cyan + Object.keys(obj).map(key => '  ' + jsonToString(key).strip.cyan + ': '.cyan + jsonToString(obj[key])).join('\n') + '\n}'.cyan
 }
 

--- a/src/setup.js
+++ b/src/setup.js
@@ -114,10 +114,11 @@ function handleField(configElement) {
  */
 function recursiveQuestion(arg, conditionFunction, cb) {
   rl.question(arg, answer => {
-    if(conditionFunction()) {
+    if(conditionFunction(answer)) {
       cb(answer)
     } else {
       recursiveQuestion(...arguments)
     }
   })
 }
+

--- a/src/setup.js
+++ b/src/setup.js
@@ -99,13 +99,13 @@ handleField(CONFIG_FIELDS.shift())
 
 function handleField(configElement) {
   if(typeof configElement === 'undefined') {
-    // There are no more questions to answer
     console.log(jsonToString(config))
     return
   }
  
   if(configElement.onlyIf && !configElement.onlyIf(config)) {
-   return  
+    handleField(CONFIG_FIELDS.shift())
+    return
   }
 
   const mapper = mapTypes[configElement.type] || (s => s) 
@@ -157,7 +157,7 @@ function recursiveQuestion(arg, conditionFunction, cb) {
  */
 function jsonToString(obj) {
   if(Array.isArray(obj)) {
-    return obj.map(i => jsonToString(i)).join(', '.cyan)
+    return '['.magenta + obj.map(i => jsonToString(i)).join(', '.cyan) + ']'.magenta
   }
   if(typeof obj === 'string') {
     return JSON.stringify(obj).red
@@ -165,6 +165,6 @@ function jsonToString(obj) {
   if(typeof obj === 'boolean') {
     return JSON.stringify(obj).green
   }
-  return '{\n'.cyan + Object.keys(obj).map(key => '  ' + jsonToString(key).strip.cyan + ': '.cyan + jsonToString(obj[key])).join('\n') + '\n}'.cyan
+  return '{\n'.magenta + Object.keys(obj).map(key => '  ' + jsonToString(key).strip.cyan + ': '.cyan + jsonToString(obj[key])).join('\n') + '\n}'.magenta
 }
 

--- a/src/setup.js
+++ b/src/setup.js
@@ -104,7 +104,7 @@ function handleField(configElement) {
     const json = jsonToString(config)
     console.log(json)
     rl.question('Write this file to config.json in the root of the source code? '.blue + '(y/n)'.inverse + ' ', answer => {
-      if(['y', 'yes'].includes(answer.toLowerCase())) {
+      if(['y', 'yes', ''].includes(answer.toLowerCase())) {
         fs.writeFileSync(path.join(__dirname, '../config.json'), json.strip)
         console.log('File written sucessfully, exiting.'.green)
         process.exit(0)

--- a/src/setup.js
+++ b/src/setup.js
@@ -178,6 +178,6 @@ function jsonToString(obj) {
   if(typeof obj === 'boolean') {
     return JSON.stringify(obj).green
   }
-  return '{\n'.magenta + Object.keys(obj).map(key => '  ' + jsonToString(key).strip.cyan + ': '.cyan + jsonToString(obj[key])).join('\n') + '\n}'.magenta
+  return '{\n'.magenta + Object.keys(obj).map(key => '  ' + jsonToString(key).strip.cyan + ': '.cyan + jsonToString(obj[key])).join(',\n'.magenta) + '\n}'.magenta
 }
 

--- a/src/setup.js
+++ b/src/setup.js
@@ -1,0 +1,33 @@
+const readline = require('readline')
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+})
+
+const defaults = require('')_
+const config = {}
+
+const CONFIG_FIELDS = [
+  {
+    field: 'owners',
+    type: 'array',
+    prompt: 'IDs of people who are listed as bot owners',
+  },
+  {
+    field: 'prefix',
+    type: 'string',
+    prompt: 'Prefix for commands to the bot'
+  },
+  {
+    field: 'adminTransparency',
+    type: 'boolean',
+    prompt: 'Should admin actions (e.g. kicking) be transparently broadcast to a channel'
+  },
+  {
+    onlyIf: config => config.adminTransparency,
+    field: 'auditChannel',
+    type: 'string',
+    prompt: 'Channel where admin actions will be broadcast to'
+  }
+]

--- a/src/setup.js
+++ b/src/setup.js
@@ -71,8 +71,9 @@ const mapTypes = {
 
 /**
  * How to convert the default values in defaults.json to something
- * the user could've typed themselves. If the output is falsey,
- * '(empty)' will be used instead.
+ * the user could've typed themselves.
+ *
+ * If the output is the empty string, it will be replaced with a red '(empty)'
  *
  * The key should be the type (as stated in CONFIG_FIELDS)
  *
@@ -80,7 +81,7 @@ const mapTypes = {
  */
 const unmapTypes = {
   array: s => s.join(' '),
-  boolean: s => ['NO', 'YES'][s]
+  boolean: s => ['no', 'yes'][s]
 }
 
 /**
@@ -104,7 +105,7 @@ function handleField(configElement) {
   if(configElement.onlyIf && !configElement.onlyIf(config)) {
    return  
   }
-  
+
   const mapper = mapTypes[configElement.type] || (s => s) 
   const validator = validateTypes[configElement.type] || (() => true)
   
@@ -114,11 +115,12 @@ function handleField(configElement) {
   const punctuation = configElement.type === 'boolean' ? '?' : ':'
 
   const defaultValue = (unmapTypes[configElement.type] || (s => s))(defaults[configElement.field])
-  const coloredDefault = defaultValue ? defaultValue.green : '(empty)'.red
-  const text = help + `${punctuation} (default is ${coloredDefault}) ${helpForType.inverse} `.replace(/ +/, ' ')
+  const coloredDefault = defaultValue !== '' ? defaultValue.green : '(empty)'.red
 
-  recursiveQuestion(text, validator, answer => {
-    config[configElement.field] = mapper(answer)
+  const text = help.blue + `${punctuation} (default is ${coloredDefault}) ${helpForType.inverse} `.replace(/ +/, ' ')
+
+  recursiveQuestion(text, s => !s || validator, answer => {
+    config[configElement.field] = answer ? mapper(answer) : defaults[configElement.field]
     handleField(CONFIG_FIELDS.shift())
   })
 }

--- a/src/setup.js
+++ b/src/setup.js
@@ -96,7 +96,9 @@ function handleField(configElement) {
   const help = configElement.prompt
   const helpForType = howToAnswer[configElement.type] || ''
 
-  const text = help + (': ' + helpForType + ' ' + helpForType).replace(/ +/, ' ')
+  const defaultValue = defaults[configElement.field]
+
+  const text = help + (': ' + '(default is ' + defaultValue + ') ' + helpForType + ' ').replace(/ +/, ' ')
 
   recursiveQuestion(text, validator, answer => {
     config[configElement.field] = mapper(answer)

--- a/src/setup.js
+++ b/src/setup.js
@@ -5,9 +5,23 @@ const rl = readline.createInterface({
   output: process.stdout
 })
 
-const defaults = require('')_
+const defaults = require('./defaults.json')
 const config = {}
 
+/**
+ * An array of objects to document which fields are needed for
+ * configuration files. Each entry should have the following
+ * fields.
+ *
+ * - field: the name of the field in the config file
+ * - type: array/boolean/string - the expected type of value from the user
+ * - prompt: a string to display to the user to help them provide an answer
+ *
+ * In addition, the following fields may be optionally be provided.
+ *
+ * - onlyIf: a function which takes an input representing the configuration file so far,
+ *   and returns true only if the user should be prompted for this field.
+ */
 const CONFIG_FIELDS = [
   {
     field: 'owners',
@@ -31,3 +45,79 @@ const CONFIG_FIELDS = [
     prompt: 'Channel where admin actions will be broadcast to'
   }
 ]
+
+/**
+ * An object to document the strings that should be appended to
+ * prompts. The key should be the type (as stated in CONFIG_FIELDS).
+ *
+ * The default is the empty string. 
+ */
+const howToAnswer = {
+  array: '(space-seperated values)',
+  boolean: '(y/n)'
+}
+
+/**
+ * How to convert an input into the object that should be added
+ * to the configuration file. The default is the identity function. (s => s)
+ *
+ * They key should be the type (as stated in CONFIG_FIELDS)
+ */
+const mapTypes = {
+  array: s => s.split(' '),
+  boolean: s => s.toLowerCase().startsWith('y')
+}
+
+/**
+ * An object to check that an input from the user isn't malformed.
+ * If it is, the user will be re-prompted. "true" means that the
+ * input is NOT malformed, but is instead valid. The default is (() => true)
+ *
+ * The key should be the type (as stated in CONFIG_FIELDS)
+ */
+const validateTypes = {
+  boolean: s => ['y', 'yes', 'n', 'no'].includes(s.toLowerCase())
+}
+
+handleField(CONFIG_FIELDS.shift())
+
+function handleField(configElement) {
+  if(configElement.onlyIf && !configElement.onlyIf(config)) {
+    return
+  }
+
+  if(typeof configElement === 'undefined') {
+    return
+  }
+
+  const mapper = mapTypes[configElement.type] || (s => s)
+  const validator = validateTypes[configElement.type] || (() => true)
+  
+  const help = configElement.prompt
+  const helpForType = howToAnswer[configElement.type] || ''
+
+  const text = help + (': ' + helpForType + ' ' + helpForType).replace(/ +/, ' ')
+
+  recursiveQuestion(text, validator, answer => {
+    config[configElement.field] = mapper(answer)
+    handleField(CONFIG_FIELDS.shift())
+  })
+}
+
+/**
+ * Prompt the user for an input until the validation function passes.
+ * When it does, call the callback.
+ *
+ * @param {string} arg - The text to use to prompt the user
+ * @param {function} conditionFunction - The function to determine whether to stop prompting the user
+ * @param {function} cb - The callback to invoke when conditionFunction returns true
+ */
+function recursiveQuestion(arg, conditionFunction, cb) {
+  rl.question(arg, answer => {
+    if(conditionFunction()) {
+      cb(answer)
+    } else {
+      recursiveQuestion(...arguments)
+    }
+  })
+}

--- a/src/setup.js
+++ b/src/setup.js
@@ -1,4 +1,6 @@
 const readline = require('readline')
+const path = require('path')
+const fs = require('fs')
 const colors = require('colors')
 
 const rl = readline.createInterface({
@@ -99,7 +101,18 @@ handleField(CONFIG_FIELDS.shift())
 
 function handleField(configElement) {
   if(typeof configElement === 'undefined') {
-    console.log(jsonToString(config))
+    const json = jsonToString(config)
+    console.log(json)
+    rl.question('Write this file to config.json in the root of the source code? '.blue + '(y/n)'.inverse + ' ', answer => {
+      if(['y', 'yes'].includes(answer.toLowerCase())) {
+        fs.writeFileSync(path.join(__dirname, '../config.json'), json.strip)
+        console.log('File written sucessfully, exiting.'.green)
+        process.exit(0)
+      } else {
+        console.log('You chose no, quiting without writing.'.red)
+        process.exit(0)
+      }
+    })
     return
   }
  

--- a/src/setup.js
+++ b/src/setup.js
@@ -81,7 +81,7 @@ const mapTypes = {
  */
 const unmapTypes = {
   array: s => s.join(' '),
-  boolean: s => ['no', 'yes'][s]
+  boolean: s => s ? 'yes' : 'no'
 }
 
 /**


### PR DESCRIPTION
# Resolves
Resolves #96 

# Changes
This pull request creates two changes
- creating a CLI
- modifying the defaults.json
- modifying documentation

The CLI works like this:
- it stores a list of all the keys and types that are required for the `config.json` file
- it stores information about these types (such as how to convert a human entry to a JSON one)
- it includes a function to keep asking the user (with colour) until they respond with something that is of the correct type
- it includes a JSON stringifier which converts a JavaScript object into a colourful JSON string (with indentation)

![CLI in action](https://user-images.githubusercontent.com/18113170/45587840-5eb8a600-b903-11e8-94d3-d613c38d90bb.png)


The documentation changes are:
- in the README and CONTRIBUTING files, explain how to run the CLI

The `defaults.json` file changes are:
- Replace the string literal `"true"` with the Boolean literal `true`; this makes it intuitive as to the correct way to state `false` (which _must_ be a false-y value and therefore cannot be `"false"`)

For discussion:
- Should the CLI be in `src` or in the root of the source code
- **Should the CLI allow you to add your token to `.env`?**

# Testing
Manually tested:
- using the CLI to write configuration files
- that admin transparency was on/off depending on user input
