### PR TITLE
Add status (now playing) command

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -49,7 +49,6 @@ client.on('ready', () => {
   | '###
   '----'
   Connected as: ${client.user.tag}!`)
-  client.user.setActivity("Bot Stuff")
 })
 
 // React randomly to other bots

--- a/src/commands/admin/SetNowPlaying.js
+++ b/src/commands/admin/SetNowPlaying.js
@@ -1,0 +1,65 @@
+const {Command} = require('discord.js-commando')
+
+let currentStatusText = 'Running in %count% guilds';
+
+module.exports = class SetNowPlaying extends Command {
+  constructor(client) {
+    super(client, {
+      name: "status",
+      group: "admin",
+      memberName: "status",
+      description: "Set the bot's status ('now playing') field",
+      examples: [
+        "status Being a cool bot",
+        "status Participating in %count% servers"
+      ],
+      args: [
+        {
+          key: "statusText",
+          prompt: "What should this bot's status be?",
+          type: "string",
+        }
+      ],
+      userPermissions: ["MANAGE_NICKNAMES"]
+    })
+
+    const onGuildCountChange = () => {
+      const specialForms = {
+        count: client.guilds.size
+      }
+
+      let text = currentStatusText
+
+      Object.keys(specialForms).forEach(specialForm => {
+        text = replace(text, specialForm, specialForms[specialForm])
+      })
+
+      client.user.setActivity(text)
+    }
+
+    client.on('ready', onGuildCountChange)
+    client.on('guildCreate', onGuildCountChange)
+    client.on('guildDelete', onGuildCountChange)
+    client.on('nowPlayingShouldChange', onGuildCountChange) // internal
+  }
+
+  run(msg, {statusText}) {
+    currentStatusText = statusText
+    msg.client.emit('nowPlayingShouldChange')
+  }
+}
+
+/**
+ * Replaces a special form like %count% inside a string
+ * into its actual value, even if it appears multiple times.
+ * Only supports special forms containing just alphabetical chars.
+ *
+ * @param {string} source - The source text
+ * @param {string} query - The name of the special form, w/o the percents
+ * @param {string} replacement - The live value that should be used as the replacement
+ * @return {string} The string, after the replacement has occured. Does not mutate the original.
+ */
+function replace(source, query, replacement) {
+  query = '%' + query.replace(/[^a-zA-Z]/g, '') + '%'
+  return source.replace(new RegExp(query, 'g'), replacement)
+}


### PR DESCRIPTION
Resolves #30 

<hr>

This command has the following syntax

```
status The bot's status goes here
```

It allows for certain special pieces of data to be inserted dynamically. The mapping of the special forms and the data they map to is in a function which is re-invoked on the following events
- the bot starts
- the bot is removed from a channel
- the bot is added to a channel
- a custom `nowPlayingShouldChange` even is emitted on the client

Currently, this object contains one mapping: `count` maps to the number of guilds the bot has membership.

The command may only be used by users who have the ability to manage nicknames. This is because nicknames are fairly similar to "Now Playing" fields in that they show additional information about users. **This permission check has not been tested**

The default status is no longer set in `bot.js`. Instead, it is left to this command's constructor. It will set up the event listeners, including the listener for `ready`. The default value is at the top of the file:

```
Running in %count% guilds
```