### PR TITLE
Edit description on the bot to make it clear that it is general purpose. Resolved #104

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 [![Waffle.io - Columns and their card count](https://badge.waffle.io/campDevs/DiscordBot.png?columns=all)](https://waffle.io/campDevs/DiscordBot?utm_source=badge)
-# Discord Bot
+# General Purpose Discord Bot
 
 > self-hosted modular bot
 
 [![Known Vulnerabilities](https://snyk.io/test/github/campdevs/discordbot/badge.svg?targetFile=package.json)](https://snyk.io/test/github/campdevs/discordbot?targetFile=package.json) [![Remix on Glitch](https://cdn.glitch.com/2703baf2-b643-4da7-ab91-7ee2a2d00b5b%2Fremix-button.svg)](https://glitch.com/edit/#!/import/github/https://github.com/campDevs/DiscordBot/)
 
-This project is a full featured, modular, JavaScript discord bot for freeCodeCamp's unnofficial Discord chat. 
+This project is a full featured, modular, JavaScript discord bot in use on the unofficial freeCodeCamp Discord chat rooms.  
 
-**Discord Chat**
+**Unofficial freeCodeCamp Discord**
  
 [![Discord Chat](discord.png)](https://discordapp.com/channels/286587968179929088/430712509180149780)
 


### PR DESCRIPTION
# Resolves
#104 

# Changes

Made it clear that the bot is general purpose and it is used on the freeCodeCamp chat, instead of making it seem that the bot is specifically for the unofficial FCC chat. 